### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: 'The path to a Markdown file to be used as a the front page'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'src/index.js'


### PR DESCRIPTION
Node 12 has been out of support since April 2022, as a result we have started the deprecation process of Node 12 for GitHub Actions. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/